### PR TITLE
Windows Bugfix: Change the regular expression to also support windows line separator

### DIFF
--- a/src/functionHelper.js
+++ b/src/functionHelper.js
@@ -33,7 +33,7 @@ function runPythonHandler(funOptions, options) {
             } else {
                 // Search for the start of the JSON result
                 // https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-output-format
-                const match = /{\n\s+"isBase64Encoded"|{\n\s+"statusCode"|{\n\s+"headers"|{\n\s+"body"/.exec(str);
+                const match = /{\r?\n\s+"isBase64Encoded"|{\r?\n\s+"statusCode"|{\r?\n\s+"headers"|{\r?\n\s+"body"/.exec(str);
                 if (match && match.index > -1) {
                     // The JSON result was in this chunk so slice it out
                     hasDetectedJson = true;


### PR DESCRIPTION
By adding the \r? on the regular expression it also match windows linebreaks, and now support linux, mac and windows.