### PR TITLE
Add support for python custom auth handler

### DIFF
--- a/src/createAuthScheme.js
+++ b/src/createAuthScheme.js
@@ -9,7 +9,7 @@ const utils = require('./utils');
 const _ = require('lodash');
 const authCanExecuteResource = require('./authCanExecuteResource');
 
-module.exports = function createAuthScheme(authFun, authorizerOptions, funName, endpointPath, options, serverlessLog, servicePath, serverless) {
+module.exports = function createAuthScheme(authFun, authorizerOptions, funName, endpointPath, options, serverlessLog, servicePath, serverless, serviceRuntime) {
   const authFunName = authorizerOptions.name;
 
   let identityHeader = 'authorization';
@@ -21,8 +21,10 @@ module.exports = function createAuthScheme(authFun, authorizerOptions, funName, 
     }
     identityHeader = identitySourceMatch[1].toLowerCase();
   }
-  
-  const funOptions = functionHelper.getFunctionOptions(authFun, funName, servicePath);
+
+  // HACK: since handlerName is used to invoke python function locally,
+  // we have to pass the authFunName instead of funcName
+  const funOptions = functionHelper.getFunctionOptions(authFun, utils.isPythonRuntime(serviceRuntime) ? authFunName : funName, servicePath, serviceRuntime);
 
   // Create Auth Scheme
   return () => ({

--- a/src/functionHelper.js
+++ b/src/functionHelper.js
@@ -6,6 +6,7 @@ const fork = require('child_process').fork;
 const _ = require('lodash');
 const path = require('path');
 const uuid = require('uuid/v4');
+const utils = require('./utils');
 
 const handlerCache = {};
 const messageCallbacks = {};
@@ -33,7 +34,7 @@ function runPythonHandler(funOptions, options) {
             } else {
                 // Search for the start of the JSON result
                 // https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-output-format
-                const match = /{[\r\n]\s+"isBase64Encoded"|{[\r\n]\s+"statusCode"|{[\r\n]\s+"headers"|{[\r\n]\s+"body"/.exec(str);
+                const match = /{[\r\n]\s+"isBase64Encoded"|{[\r\n]\s+"statusCode"|{[\r\n]\s+"headers"|{[\r\n]\s+"body"|{[\r\n]\s+"principalId"/.exec(str);
                 if (match && match.index > -1) {
                     // The JSON result was in this chunk so slice it out
                     hasDetectedJson = true;
@@ -160,7 +161,7 @@ module.exports = {
     }
     let user_python = true
     let handler = null;
-    if (['python2.7', 'python3.6'].indexOf(funOptions['serviceRuntime']) !== -1){
+    if (utils.isPythonRuntime(funOptions['serviceRuntime'])) {
       handler = runPythonHandler(funOptions, options)
     } else {
       debugLog(`Loading handler... (${funOptions.handlerPath})`);

--- a/src/index.js
+++ b/src/index.js
@@ -384,7 +384,7 @@ class Offline {
         this.serverlessLog(`${method} ${fullPath}`);
 
         // If the endpoint has an authorization function, create an authStrategy for the route
-        const authStrategyName = this.options.noAuth ? null : this._configureAuthorization(endpoint, funName, method, epath, servicePath);
+        const authStrategyName = this.options.noAuth ? null : this._configureAuthorization(endpoint, funName, method, epath, servicePath, serviceRuntime);
 
         let cors = null;
         if (endpoint.cors) {
@@ -805,7 +805,7 @@ class Offline {
     });
   }
 
-  _configureAuthorization(endpoint, funName, method, epath, servicePath) {
+  _configureAuthorization(endpoint, funName, method, epath, servicePath, serviceRuntime) {
     let authStrategyName = null;
     if (endpoint.authorizer) {
       let authFunctionName = endpoint.authorizer;
@@ -863,7 +863,8 @@ class Offline {
         this.options,
         this.serverlessLog,
         servicePath,
-        this.serverless
+        this.serverless,
+        serviceRuntime
       );
 
       // Set the auth scheme and strategy on the server

--- a/src/utils.js
+++ b/src/utils.js
@@ -17,4 +17,5 @@ module.exports = {
   // Detect the toString encoding from the request headers content-type
   // enhance if further content types need to be non utf8 encoded.
   detectEncoding: request => _.includes(request.headers['content-type'], 'multipart/form-data') ? 'binary' : 'utf8',
+  isPythonRuntime: runtime => runtime.startsWith('python')
 };


### PR DESCRIPTION
Since python runtime utilizes `serverless invoke local` command for execution, the implementation goes bit hacky, but I believe this PR works in most use cases.