### PR TITLE
added python3.7 runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To do so, it starts an HTTP server that handles the request's lifecycle like API
 
 **Features:**
 
-* Nodejs λ, Python 2.7, Python 3.6, and Ruby only.
+* Nodejs λ, Python 2.7, Python 3.6, Python 3.7, and Ruby only.
 * Velocity templates support.
 * Lazy loading of your files with require cache invalidation: no need for a reloading tool like Nodemon.
 * And more: integrations, authorizers, proxies, timeouts, responseParameters, HTTPS, Babel runtime, CORS, etc...

--- a/src/index.js
+++ b/src/index.js
@@ -324,9 +324,10 @@ class Offline {
     const apiKeys = this.service.provider.apiKeys;
     const protectedRoutes = [];
 
-    if (['nodejs', 'nodejs4.3', 'nodejs6.10', 'nodejs8.10', 'babel', 'python2.7', 'python3.6', 'ruby2.5'].indexOf(serviceRuntime) === -1) {
+    if (utils.supportedRuntimes.indexOf(serviceRuntime) === -1) {
       this.printBlankLine();
       this.serverlessLog(`Warning: found unsupported runtime '${serviceRuntime}'`);
+      this.serverlessLog(`Supported runtimes: ${utils.supportedRuntimes}`);
 
       return;
     }

--- a/src/utils.js
+++ b/src/utils.js
@@ -17,5 +17,16 @@ module.exports = {
   // Detect the toString encoding from the request headers content-type
   // enhance if further content types need to be non utf8 encoded.
   detectEncoding: request => _.includes(request.headers['content-type'], 'multipart/form-data') ? 'binary' : 'utf8',
-  isProxyRuntime: runtime => { return runtime.startsWith('python') || runtime.startsWith('ruby') }
+  isProxyRuntime: runtime => { return runtime.startsWith('python') || runtime.startsWith('ruby') },
+  supportedRuntimes: [
+    'nodejs',
+    'nodejs4.3',
+    'nodejs6.10',
+    'nodejs8.10',
+    'babel',
+    'python2.7',
+    'python3.6',
+    'python3.7',
+    'ruby2.5',
+  ],
 };


### PR DESCRIPTION
Hi there

AWS supports [python3.7](https://aws.amazon.com/about-aws/whats-new/2018/11/aws-lambda-supports-python-37/), this PR just adds it to the list. Tested on osx with python 3.7.0 and 3.7.2