### PR TITLE
Migrate a fix for a breaking change from serverless-offline

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1044,8 +1044,4 @@ class Offline {
   }
 }
 
-// Serverless exits with code 1 when a promise rejection is unhandled. Not AWS.
-// Users can still use their own unhandledRejection event though.
-process.removeAllListeners('unhandledRejection');
-
 module.exports = Offline;


### PR DESCRIPTION
serverless-offline issue: https://github.com/dherault/serverless-offline/pull/767

With `unhandledRejection` removed serverless does not update exit code when fails. This leads to a successful deploy status for a failed deploy.