### PR TITLE
Update supported runtimes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: node_js
 node_js:
   - node
-  - '7'
-  - '6'
-  - '5'
-  - '4.3.2'
+  - '8'
+  - '10'
+  - '12'
 notifications:
   email: false

--- a/src/utils.js
+++ b/src/utils.js
@@ -19,14 +19,14 @@ module.exports = {
   detectEncoding: request => _.includes(request.headers['content-type'], 'multipart/form-data') ? 'binary' : 'utf8',
   isProxyRuntime: runtime => { return runtime.startsWith('python') || runtime.startsWith('ruby') },
   supportedRuntimes: [
-    'nodejs',
-    'nodejs4.3',
-    'nodejs6.10',
     'nodejs8.10',
+    'nodejs10.x',
+    'nodejs12.x',
     'babel',
     'python2.7',
     'python3.6',
     'python3.7',
+    'python3.8',
     'ruby2.5',
   ],
 };


### PR DESCRIPTION
Update runtime checks to match latest AWS supported runtimes.

Also closes: https://github.com/alhazmy13/serverless-offline-python/issues/15